### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/Action CI.yml
+++ b/.github/workflows/Action CI.yml
@@ -7,6 +7,10 @@ on:
       - 'README.md'
       - 'LICENSE'
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/Action CI.yml
+++ b/.github/workflows/Action CI.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  actions: read
+  actions: write
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/YuKongA/Updater-KMP/security/code-scanning/1](https://github.com/YuKongA/Updater-KMP/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum permissions required. Based on the workflow's actions:
1. `contents: read` is needed for `actions/checkout@v4` to fetch the repository's code.
2. `actions: read` is required for `actions/upload-artifact@v4` to upload artifacts.
3. No other permissions appear necessary for the workflow.

The `permissions` block will be added at the root of the workflow file, ensuring it applies to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
