### PR TITLE
core: drop cryptography-kotlin for a pure-Kotlin crypto impl

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ After logging in to your Xiaomi account, you will use the miotaV3-v2 interface t
 
 - [compose-imageloader](https://github.com/qdsfdhvh/compose-imageloader) with MIT License
 - [compose-multiplatform](https://github.com/JetBrains/compose-multiplatform) with Apache-2.0 license
-- [cryptography-kotlin](https://github.com/whyoleg/cryptography-kotlin) with Apache-2.0 license
 - [ktor](https://github.com/ktorio/ktor) with Apache-2.0 license
 - [kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) with Apache-2.0 license
 - [miuix](https://github.com/miuix-kotlin-multiplatform/miuix) with Apache-2.0 license

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 plugins {
     alias(libs.plugins.kotlin.multiplatform)
@@ -6,15 +7,16 @@ plugins {
 }
 
 kotlin {
-    fun KotlinNativeTarget.cliBinary() {
+    fun KotlinNativeTarget.cliBinary(vararg stripArgs: String) {
         binaries.executable {
             entryPoint = "main"
             baseName = "updater"
+            if (buildType == NativeBuildType.RELEASE) linkerOpts(*stripArgs)
         }
     }
-    mingwX64 { cliBinary() }
-    linuxX64 { cliBinary() }
-    macosArm64 { cliBinary() }
+    mingwX64 { cliBinary("-Wl,-s") }
+    linuxX64 { cliBinary("-Wl,-s") }
+    macosArm64 { cliBinary("-Wl,-x") }
 
     sourceSets {
         commonMain.dependencies {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -60,6 +60,7 @@ kotlin {
             implementation(libs.kotlinx.datetime)
             implementation(libs.okio)
         }
+        commonTest.dependencies { implementation(kotlin("test")) }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }
         appleMain.dependencies { implementation(libs.ktor.client.darwin) }
         desktopMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -58,7 +58,6 @@ kotlin {
             api(libs.kotlinx.serialization.json)
             implementation(libs.kotlinx.serialization.protobuf)
             implementation(libs.kotlinx.datetime)
-            implementation(libs.cryptography.provider.optimal)
             implementation(libs.okio)
         }
         androidMain.dependencies { implementation(libs.ktor.client.cio) }

--- a/core/src/androidMain/kotlin/platform/Crypto.android.kt
+++ b/core/src/androidMain/kotlin/platform/Crypto.android.kt
@@ -17,7 +17,7 @@ actual suspend fun ownDecrypt(encryptedText: String, encodedIv: String): String 
     val encrypted = Base64.decode(encryptedText)
     val iv = Base64.decode(encodedIv)
     val cipher = KeyStoreUtils.getDecryptionCipher(iv)
-    return String(cipher.doFinal(encrypted))
+    return cipher.doFinal(encrypted).decodeToString()
 }
 
 actual suspend fun generateKey() {

--- a/core/src/appleMain/kotlin/platform/Crypto.apple.kt
+++ b/core/src/appleMain/kotlin/platform/Crypto.apple.kt
@@ -1,14 +1,11 @@
 package platform
 
-import dev.whyoleg.cryptography.CryptographyProvider
-import dev.whyoleg.cryptography.DelicateCryptographyApi
-import dev.whyoleg.cryptography.algorithms.AES
-import dev.whyoleg.cryptography.operations.IvCipher
+import platform.crypto.AesCbc
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
-// AES-CBC with a Keychain-held key; only the ciphertext + IV reach
-// NSUserDefaults, so clearing them on logout is enough to invalidate credentials.
+// AES-CBC with a Keychain-held key; only ciphertext + IV land in NSUserDefaults,
+// so clearing them on logout invalidates stored credentials.
 private const val KEY_SIZE = 32
 private const val IV_SIZE = 16
 
@@ -18,24 +15,17 @@ actual suspend fun generateKey() {
     }
 }
 
-@OptIn(ExperimentalEncodingApi::class, DelicateCryptographyApi::class)
+@OptIn(ExperimentalEncodingApi::class)
 actual suspend fun ownEncrypt(string: String): Pair<String, String> {
     val key = KeychainKeyStore.load() ?: return Pair("", "")
     val iv = KeychainKeyStore.randomBytes(IV_SIZE)
-    val encrypted = aesCipher(key).encryptWithIv(iv, string.encodeToByteArray())
+    val encrypted = AesCbc.encrypt(key, iv, string.encodeToByteArray())
     return Pair(Base64.encode(encrypted), Base64.encode(iv))
 }
 
-@OptIn(ExperimentalEncodingApi::class, DelicateCryptographyApi::class)
+@OptIn(ExperimentalEncodingApi::class)
 actual suspend fun ownDecrypt(encryptedText: String, encodedIv: String): String {
     val key = KeychainKeyStore.load() ?: return ""
-    val decrypted = aesCipher(key).decryptWithIv(Base64.decode(encodedIv), Base64.decode(encryptedText))
+    val decrypted = AesCbc.decrypt(key, Base64.decode(encodedIv), Base64.decode(encryptedText))
     return decrypted.decodeToString()
-}
-
-@OptIn(DelicateCryptographyApi::class)
-private suspend fun aesCipher(keyBytes: ByteArray): IvCipher {
-    val aesCbc = CryptographyProvider.Default.get(AES.CBC)
-    val key = aesCbc.keyDecoder().decodeFromByteArray(AES.Key.Format.RAW, keyBytes)
-    return key.cipher(true) // PKCS5Padding, matching the other platforms
 }

--- a/core/src/commonMain/kotlin/data/repository/LoginService.kt
+++ b/core/src/commonMain/kotlin/data/repository/LoginService.kt
@@ -4,10 +4,6 @@ import data.DataHelper
 import data.LoginResult
 import data.storage.CredentialsStorage
 import data.storage.LoginFlowStorage
-import dev.whyoleg.cryptography.CryptographyProvider
-import dev.whyoleg.cryptography.DelicateCryptographyApi
-import dev.whyoleg.cryptography.algorithms.MD5
-import dev.whyoleg.cryptography.algorithms.SHA1
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.cookies.AcceptAllCookiesStorage
 import io.ktor.client.plugins.cookies.HttpCookies
@@ -31,6 +27,8 @@ import kotlinx.serialization.json.booleanOrNull
 import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonPrimitive
+import platform.crypto.md5
+import platform.crypto.sha1
 import platform.httpClientPlatform
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
@@ -252,18 +250,16 @@ class LoginService(
         }
     }
 
-    @OptIn(DelicateCryptographyApi::class)
-    private suspend fun md5Hash(input: String): String {
-        val md = CryptographyProvider.Default.get(MD5)
-        return md.hasher().hash(input.encodeToByteArray()).joinToString("") {
+    private fun md5Hash(input: String): String {
+        return md5(input.encodeToByteArray()).joinToString("") {
             val hex = (it.toInt() and 0xFF).toString(16).uppercase()
             if (hex.length == 1) "0$hex" else hex
         }
     }
 
-    @OptIn(DelicateCryptographyApi::class, ExperimentalEncodingApi::class)
-    private suspend fun xiaomiClientSign(nonce: String, ssecurity: String): String {
-        val digest = CryptographyProvider.Default.get(SHA1).hasher().hash("nonce=$nonce&$ssecurity".encodeToByteArray())
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun xiaomiClientSign(nonce: String, ssecurity: String): String {
+        val digest = sha1("nonce=$nonce&$ssecurity".encodeToByteArray())
         return Base64.Default.encode(digest)
     }
 

--- a/core/src/commonMain/kotlin/platform/Crypto.kt
+++ b/core/src/commonMain/kotlin/platform/Crypto.kt
@@ -1,9 +1,6 @@
 package platform
 
-import dev.whyoleg.cryptography.CryptographyProvider
-import dev.whyoleg.cryptography.DelicateCryptographyApi
-import dev.whyoleg.cryptography.algorithms.AES
-import dev.whyoleg.cryptography.operations.IvCipher
+import platform.crypto.AesCbc
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -11,43 +8,18 @@ private val iv = "0102030405060708".encodeToByteArray()
 
 expect suspend fun generateKey()
 
-/**
- * Generate a Cipher to be used by the xiaomi server.
- */
-suspend fun miuiCipher(securityKey: ByteArray): IvCipher {
-    val aesCBC = CryptographyProvider.Default.get(AES.CBC) // AES CBC
-    val key = aesCBC.keyDecoder().decodeFromByteArray(AES.Key.Format.RAW, securityKey)
-    return key.cipher(true) // PKCS5Padding
-}
-
-/**
- * Encrypt the JSON used for the request using AES.
- *
- * @param jsonRequest: JSON used for the request
- * @param securityKey: Security key
- *
- * @return Encrypted JSON text
- */
-@OptIn(ExperimentalEncodingApi::class, DelicateCryptographyApi::class)
-suspend fun miuiEncrypt(jsonRequest: String, securityKey: ByteArray): String {
-    val cipher = miuiCipher(securityKey)
-    val encrypted = cipher.encryptWithIv(iv, jsonRequest.encodeToByteArray())
+/** AES-CBC encrypt the request JSON, returned as URL-safe Base64. */
+@OptIn(ExperimentalEncodingApi::class)
+fun miuiEncrypt(jsonRequest: String, securityKey: ByteArray): String {
+    val encrypted = AesCbc.encrypt(securityKey, iv, jsonRequest.encodeToByteArray())
     return Base64.UrlSafe.encode(encrypted)
 }
 
-/**
- * Decrypt the returned content using AES.
- *
- * @param encryptedText: Returned content
- * @param securityKey: Security key
- *
- * @return Decrypted return content text
- */
-@OptIn(DelicateCryptographyApi::class, ExperimentalEncodingApi::class)
-suspend fun miuiDecrypt(encryptedText: String, securityKey: ByteArray): String {
-    val cipher = miuiCipher(securityKey)
+/** AES-CBC decrypt a Base64 server response back to plaintext JSON. */
+@OptIn(ExperimentalEncodingApi::class)
+fun miuiDecrypt(encryptedText: String, securityKey: ByteArray): String {
     val encryptedTextBytes = Base64.Mime.decode(encryptedText)
-    val decryptedTextBytes = cipher.decryptWithIv(iv, encryptedTextBytes)
+    val decryptedTextBytes = AesCbc.decrypt(securityKey, iv, encryptedTextBytes)
     return decryptedTextBytes.decodeToString()
 }
 

--- a/core/src/commonMain/kotlin/platform/crypto/Aes.kt
+++ b/core/src/commonMain/kotlin/platform/crypto/Aes.kt
@@ -29,15 +29,16 @@ internal object AesCbc {
         require(ciphertext.size % BLOCK == 0 && ciphertext.isNotEmpty()) { "AES-CBC ciphertext must be a positive multiple of 16 bytes" }
         val rk = RoundKeys(key)
         val out = ByteArray(ciphertext.size)
-        var prev = iv.copyOf()
-        val block = ByteArray(BLOCK)
+        val prev = iv.copyOf()
+        val work = ByteArray(BLOCK)
         var offset = 0
         while (offset < ciphertext.size) {
-            ciphertext.copyInto(block, 0, offset, offset + BLOCK)
-            val decrypted = block.copyOf()
-            decryptBlock(decrypted, rk)
-            for (i in 0 until BLOCK) out[offset + i] = (decrypted[i].toInt() xor prev[i].toInt()).toByte()
-            prev = block.copyOf()
+            ciphertext.copyInto(work, 0, offset, offset + BLOCK)
+            decryptBlock(work, rk)
+            for (i in 0 until BLOCK) {
+                out[offset + i] = (work[i].toInt() xor prev[i].toInt()).toByte()
+                prev[i] = ciphertext[offset + i]
+            }
             offset += BLOCK
         }
         return pkcs7Unpad(out)

--- a/core/src/commonMain/kotlin/platform/crypto/Aes.kt
+++ b/core/src/commonMain/kotlin/platform/crypto/Aes.kt
@@ -1,0 +1,236 @@
+package platform.crypto
+
+/**
+ * Dependency-free AES-CBC/PKCS#7 (128/192/256-bit keys), so native binaries drop the
+ * static OpenSSL link. IV is explicit and never prefixed to the ciphertext, matching
+ * the previous provider's encryptWithIv/decryptWithIv.
+ */
+internal object AesCbc {
+    private const val BLOCK = 16
+
+    fun encrypt(key: ByteArray, iv: ByteArray, plaintext: ByteArray): ByteArray {
+        require(iv.size == BLOCK) { "AES-CBC IV must be 16 bytes" }
+        val rk = RoundKeys(key)
+        val padded = pkcs7Pad(plaintext)
+        val out = ByteArray(padded.size)
+        val prev = iv.copyOf()
+        var offset = 0
+        while (offset < padded.size) {
+            for (i in 0 until BLOCK) prev[i] = (padded[offset + i].toInt() xor prev[i].toInt()).toByte()
+            encryptBlock(prev, rk)
+            prev.copyInto(out, offset)
+            offset += BLOCK
+        }
+        return out
+    }
+
+    fun decrypt(key: ByteArray, iv: ByteArray, ciphertext: ByteArray): ByteArray {
+        require(iv.size == BLOCK) { "AES-CBC IV must be 16 bytes" }
+        require(ciphertext.size % BLOCK == 0 && ciphertext.isNotEmpty()) { "AES-CBC ciphertext must be a positive multiple of 16 bytes" }
+        val rk = RoundKeys(key)
+        val out = ByteArray(ciphertext.size)
+        var prev = iv.copyOf()
+        val block = ByteArray(BLOCK)
+        var offset = 0
+        while (offset < ciphertext.size) {
+            ciphertext.copyInto(block, 0, offset, offset + BLOCK)
+            val decrypted = block.copyOf()
+            decryptBlock(decrypted, rk)
+            for (i in 0 until BLOCK) out[offset + i] = (decrypted[i].toInt() xor prev[i].toInt()).toByte()
+            prev = block.copyOf()
+            offset += BLOCK
+        }
+        return pkcs7Unpad(out)
+    }
+
+    private fun pkcs7Pad(data: ByteArray): ByteArray {
+        val padLen = BLOCK - (data.size % BLOCK)
+        val out = data.copyOf(data.size + padLen)
+        for (i in data.size until out.size) out[i] = padLen.toByte()
+        return out
+    }
+
+    private fun pkcs7Unpad(data: ByteArray): ByteArray {
+        val padLen = data.last().toInt() and 0xFF
+        require(padLen in 1..BLOCK && padLen <= data.size) { "Invalid PKCS#7 padding" }
+        for (i in data.size - padLen until data.size) {
+            require((data[i].toInt() and 0xFF) == padLen) { "Invalid PKCS#7 padding" }
+        }
+        return data.copyOf(data.size - padLen)
+    }
+
+    // --- AES core ---------------------------------------------------------
+
+    private class RoundKeys(key: ByteArray) {
+        val rounds: Int
+        val words: IntArray
+
+        init {
+            val nk = key.size / 4
+            require(key.size == 16 || key.size == 24 || key.size == 32) { "AES key must be 16/24/32 bytes" }
+            rounds = nk + 6
+            val total = 4 * (rounds + 1)
+            words = IntArray(total)
+            for (i in 0 until nk) {
+                words[i] = (key[4 * i].toInt() and 0xFF shl 24) or
+                    (key[4 * i + 1].toInt() and 0xFF shl 16) or
+                    (key[4 * i + 2].toInt() and 0xFF shl 8) or
+                    (key[4 * i + 3].toInt() and 0xFF)
+            }
+            var rcon = 0x01
+            for (i in nk until total) {
+                var temp = words[i - 1]
+                if (i % nk == 0) {
+                    temp = subWord(rotWord(temp)) xor (rcon shl 24)
+                    rcon = xtime(rcon)
+                } else if (nk > 6 && i % nk == 4) {
+                    temp = subWord(temp)
+                }
+                words[i] = words[i - nk] xor temp
+            }
+        }
+    }
+
+    private fun encryptBlock(state: ByteArray, rk: RoundKeys) {
+        addRoundKey(state, rk, 0)
+        for (round in 1 until rk.rounds) {
+            subBytes(state)
+            shiftRows(state)
+            mixColumns(state)
+            addRoundKey(state, rk, round)
+        }
+        subBytes(state)
+        shiftRows(state)
+        addRoundKey(state, rk, rk.rounds)
+    }
+
+    private fun decryptBlock(state: ByteArray, rk: RoundKeys) {
+        addRoundKey(state, rk, rk.rounds)
+        for (round in rk.rounds - 1 downTo 1) {
+            invShiftRows(state)
+            invSubBytes(state)
+            addRoundKey(state, rk, round)
+            invMixColumns(state)
+        }
+        invShiftRows(state)
+        invSubBytes(state)
+        addRoundKey(state, rk, 0)
+    }
+
+    private fun addRoundKey(s: ByteArray, rk: RoundKeys, round: Int) {
+        for (c in 0 until 4) {
+            val w = rk.words[round * 4 + c]
+            s[4 * c] = (s[4 * c].toInt() xor (w ushr 24 and 0xFF)).toByte()
+            s[4 * c + 1] = (s[4 * c + 1].toInt() xor (w ushr 16 and 0xFF)).toByte()
+            s[4 * c + 2] = (s[4 * c + 2].toInt() xor (w ushr 8 and 0xFF)).toByte()
+            s[4 * c + 3] = (s[4 * c + 3].toInt() xor (w and 0xFF)).toByte()
+        }
+    }
+
+    private fun subBytes(s: ByteArray) {
+        for (i in s.indices) s[i] = SBOX[s[i].toInt() and 0xFF]
+    }
+
+    private fun invSubBytes(s: ByteArray) {
+        for (i in s.indices) s[i] = INV_SBOX[s[i].toInt() and 0xFF]
+    }
+
+    private fun shiftRows(s: ByteArray) {
+        val t = ByteArray(16)
+        for (r in 0 until 4) for (c in 0 until 4) t[r + 4 * c] = s[r + 4 * ((c + r) % 4)]
+        t.copyInto(s)
+    }
+
+    private fun invShiftRows(s: ByteArray) {
+        val t = ByteArray(16)
+        for (r in 0 until 4) for (c in 0 until 4) t[r + 4 * c] = s[r + 4 * ((c - r + 4) % 4)]
+        t.copyInto(s)
+    }
+
+    private fun mixColumns(s: ByteArray) {
+        for (c in 0 until 4) {
+            val i = 4 * c
+            val a0 = s[i].toInt() and 0xFF
+            val a1 = s[i + 1].toInt() and 0xFF
+            val a2 = s[i + 2].toInt() and 0xFF
+            val a3 = s[i + 3].toInt() and 0xFF
+            s[i] = (gmul(a0, 2) xor gmul(a1, 3) xor a2 xor a3).toByte()
+            s[i + 1] = (a0 xor gmul(a1, 2) xor gmul(a2, 3) xor a3).toByte()
+            s[i + 2] = (a0 xor a1 xor gmul(a2, 2) xor gmul(a3, 3)).toByte()
+            s[i + 3] = (gmul(a0, 3) xor a1 xor a2 xor gmul(a3, 2)).toByte()
+        }
+    }
+
+    private fun invMixColumns(s: ByteArray) {
+        for (c in 0 until 4) {
+            val i = 4 * c
+            val a0 = s[i].toInt() and 0xFF
+            val a1 = s[i + 1].toInt() and 0xFF
+            val a2 = s[i + 2].toInt() and 0xFF
+            val a3 = s[i + 3].toInt() and 0xFF
+            s[i] = (gmul(a0, 14) xor gmul(a1, 11) xor gmul(a2, 13) xor gmul(a3, 9)).toByte()
+            s[i + 1] = (gmul(a0, 9) xor gmul(a1, 14) xor gmul(a2, 11) xor gmul(a3, 13)).toByte()
+            s[i + 2] = (gmul(a0, 13) xor gmul(a1, 9) xor gmul(a2, 14) xor gmul(a3, 11)).toByte()
+            s[i + 3] = (gmul(a0, 11) xor gmul(a1, 13) xor gmul(a2, 9) xor gmul(a3, 14)).toByte()
+        }
+    }
+
+    private fun rotWord(w: Int): Int = (w shl 8) or (w ushr 24)
+
+    private fun subWord(w: Int): Int =
+        (SBOX[w ushr 24 and 0xFF].toInt() and 0xFF shl 24) or
+            (SBOX[w ushr 16 and 0xFF].toInt() and 0xFF shl 16) or
+            (SBOX[w ushr 8 and 0xFF].toInt() and 0xFF shl 8) or
+            (SBOX[w and 0xFF].toInt() and 0xFF)
+
+    private fun xtime(x: Int): Int {
+        val shifted = x shl 1
+        return (if (x and 0x80 != 0) shifted xor 0x1B else shifted) and 0xFF
+    }
+
+    private fun gmul(a: Int, b: Int): Int {
+        var aa = a and 0xFF
+        var bb = b and 0xFF
+        var p = 0
+        repeat(8) {
+            if (bb and 1 != 0) p = p xor aa
+            aa = xtime(aa)
+            bb = bb shr 1
+        }
+        return p and 0xFF
+    }
+
+    // S-box + inverse, derived from GF(2^8) inverses and the affine map (no hand-typed tables).
+    private val SBOX: ByteArray
+    private val INV_SBOX: ByteArray
+
+    init {
+        val inv = IntArray(256)
+        // GF(2^8) inverses via log/antilog tables (generator 3).
+        val log = IntArray(256)
+        val alog = IntArray(256)
+        var x = 1
+        for (i in 0 until 255) {
+            alog[i] = x
+            log[x] = i
+            x = x xor xtime(x) // multiply by 3: x*2 xor x
+        }
+        inv[0] = 0
+        for (i in 1 until 256) inv[i] = alog[(255 - log[i]) % 255]
+
+        val sbox = ByteArray(256)
+        val invSbox = ByteArray(256)
+        for (i in 0 until 256) {
+            val b = inv[i]
+            var s = b
+            s = s xor rotl8(b, 1) xor rotl8(b, 2) xor rotl8(b, 3) xor rotl8(b, 4) xor 0x63
+            s = s and 0xFF
+            sbox[i] = s.toByte()
+            invSbox[s] = i.toByte()
+        }
+        SBOX = sbox
+        INV_SBOX = invSbox
+    }
+
+    private fun rotl8(b: Int, n: Int): Int = ((b shl n) or (b ushr (8 - n))) and 0xFF
+}

--- a/core/src/commonMain/kotlin/platform/crypto/Md5.kt
+++ b/core/src/commonMain/kotlin/platform/crypto/Md5.kt
@@ -1,0 +1,87 @@
+package platform.crypto
+
+// Per-round left-rotate amounts (RFC 1321).
+private val MD5_SHIFTS = intArrayOf(
+    7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+    5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+    4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+    6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+)
+
+// K[i] = floor(2^32 * abs(sin(i+1))), from RFC 1321.
+private val MD5_K = longArrayOf(
+    0xd76aa478, 0xe8c7b756, 0x242070db, 0xc1bdceee,
+    0xf57c0faf, 0x4787c62a, 0xa8304613, 0xfd469501,
+    0x698098d8, 0x8b44f7af, 0xffff5bb1, 0x895cd7be,
+    0x6b901122, 0xfd987193, 0xa679438e, 0x49b40821,
+    0xf61e2562, 0xc040b340, 0x265e5a51, 0xe9b6c7aa,
+    0xd62f105d, 0x02441453, 0xd8a1e681, 0xe7d3fbc8,
+    0x21e1cde6, 0xc33707d6, 0xf4d50d87, 0x455a14ed,
+    0xa9e3e905, 0xfcefa3f8, 0x676f02d9, 0x8d2a4c8a,
+    0xfffa3942, 0x8771f681, 0x6d9d6122, 0xfde5380c,
+    0xa4beea44, 0x4bdecfa9, 0xf6bb4b60, 0xbebfbc70,
+    0x289b7ec6, 0xeaa127fa, 0xd4ef3085, 0x04881d05,
+    0xd9d4d039, 0xe6db99e5, 0x1fa27cf8, 0xc4ac5665,
+    0xf4292244, 0x432aff97, 0xab9423a7, 0xfc93a039,
+    0x655b59c3, 0x8f0ccc92, 0xffeff47d, 0x85845dd1,
+    0x6fa87e4f, 0xfe2ce6e0, 0xa3014314, 0x4e0811a1,
+    0xf7537e82, 0xbd3af235, 0x2ad7d2bb, 0xeb86d391,
+).map { it.toInt() }.toIntArray()
+
+/** Dependency-free MD5 (RFC 1321); only used for the Xiaomi login `hash`. */
+internal fun md5(message: ByteArray): ByteArray {
+    var a0 = 0x67452301
+    var b0 = -0x10325477 // 0xefcdab89
+    var c0 = -0x67452302 // 0x98badcfe
+    var d0 = 0x10325476
+
+    val msgLen = message.size
+    val bitLen = msgLen.toLong() * 8
+    val padLen = ((56 - (msgLen + 1) % 64) + 64) % 64
+    val padded = ByteArray(msgLen + 1 + padLen + 8)
+    message.copyInto(padded)
+    padded[msgLen] = 0x80.toByte()
+    for (i in 0 until 8) padded[padded.size - 8 + i] = (bitLen ushr (8 * i)).toByte()
+
+    val m = IntArray(16)
+    var chunk = 0
+    while (chunk < padded.size) {
+        for (i in 0 until 16) {
+            val j = chunk + i * 4
+            m[i] = (padded[j].toInt() and 0xFF) or
+                (padded[j + 1].toInt() and 0xFF shl 8) or
+                (padded[j + 2].toInt() and 0xFF shl 16) or
+                (padded[j + 3].toInt() and 0xFF shl 24)
+        }
+        var a = a0
+        var b = b0
+        var c = c0
+        var d = d0
+        for (i in 0 until 64) {
+            val f: Int
+            val g: Int
+            when (i / 16) {
+                0 -> { f = (b and c) or (b.inv() and d); g = i }
+                1 -> { f = (d and b) or (d.inv() and c); g = (5 * i + 1) % 16 }
+                2 -> { f = b xor c xor d; g = (3 * i + 5) % 16 }
+                else -> { f = c xor (b or d.inv()); g = (7 * i) % 16 }
+            }
+            val rotated = (a + f + MD5_K[i] + m[g]).rotateLeft(MD5_SHIFTS[i])
+            a = d
+            d = c
+            c = b
+            b += rotated
+        }
+        a0 += a
+        b0 += b
+        c0 += c
+        d0 += d
+        chunk += 64
+    }
+
+    val out = ByteArray(16)
+    intArrayOf(a0, b0, c0, d0).forEachIndexed { idx, v ->
+        for (i in 0 until 4) out[idx * 4 + i] = (v ushr (8 * i)).toByte()
+    }
+    return out
+}

--- a/core/src/commonMain/kotlin/platform/crypto/Sha1.kt
+++ b/core/src/commonMain/kotlin/platform/crypto/Sha1.kt
@@ -1,0 +1,66 @@
+package platform.crypto
+
+/** Dependency-free SHA-1 (RFC 3174); only used for the Xiaomi `clientSign`. */
+internal fun sha1(message: ByteArray): ByteArray {
+    var h0 = 0x67452301
+    var h1 = -0x10325477 // 0xEFCDAB89
+    var h2 = -0x67452302 // 0x98BADCFE
+    var h3 = 0x10325476
+    var h4 = -0x3c2d1e10 // 0xC3D2E1F0
+
+    val msgLen = message.size
+    val bitLen = msgLen.toLong() * 8
+    val padLen = ((56 - (msgLen + 1) % 64) + 64) % 64
+    val padded = ByteArray(msgLen + 1 + padLen + 8)
+    message.copyInto(padded)
+    padded[msgLen] = 0x80.toByte()
+    for (i in 0 until 8) padded[padded.size - 1 - i] = (bitLen ushr (8 * i)).toByte()
+
+    val w = IntArray(80)
+    var chunk = 0
+    while (chunk < padded.size) {
+        for (i in 0 until 16) {
+            val j = chunk + i * 4
+            w[i] = (padded[j].toInt() and 0xFF shl 24) or
+                (padded[j + 1].toInt() and 0xFF shl 16) or
+                (padded[j + 2].toInt() and 0xFF shl 8) or
+                (padded[j + 3].toInt() and 0xFF)
+        }
+        for (i in 16 until 80) {
+            w[i] = (w[i - 3] xor w[i - 8] xor w[i - 14] xor w[i - 16]).rotateLeft(1)
+        }
+        var a = h0
+        var b = h1
+        var c = h2
+        var d = h3
+        var e = h4
+        for (i in 0 until 80) {
+            val f: Int
+            val k: Int
+            when (i / 20) {
+                0 -> { f = (b and c) or (b.inv() and d); k = 0x5A827999 }
+                1 -> { f = b xor c xor d; k = 0x6ED9EBA1 }
+                2 -> { f = (b and c) or (b and d) or (c and d); k = -0x70e44324 } // 0x8F1BBCDC
+                else -> { f = b xor c xor d; k = -0x359d3e2a } // 0xCA62C1D6
+            }
+            val tmp = a.rotateLeft(5) + f + e + k + w[i]
+            e = d
+            d = c
+            c = b.rotateLeft(30)
+            b = a
+            a = tmp
+        }
+        h0 += a
+        h1 += b
+        h2 += c
+        h3 += d
+        h4 += e
+        chunk += 64
+    }
+
+    val out = ByteArray(20)
+    intArrayOf(h0, h1, h2, h3, h4).forEachIndexed { idx, v ->
+        for (i in 0 until 4) out[idx * 4 + i] = (v ushr (24 - 8 * i)).toByte()
+    }
+    return out
+}

--- a/core/src/commonTest/kotlin/CryptoVectorsTest.kt
+++ b/core/src/commonTest/kotlin/CryptoVectorsTest.kt
@@ -1,0 +1,104 @@
+import platform.crypto.AesCbc
+import platform.crypto.md5
+import platform.crypto.sha1
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CryptoVectorsTest {
+
+    private fun hex(bytes: ByteArray): String =
+        bytes.joinToString("") { (it.toInt() and 0xFF).toString(16).padStart(2, '0') }
+
+    private fun bytes(hex: String): ByteArray =
+        ByteArray(hex.length / 2) { ((hex[it * 2].digitToInt(16) shl 4) or hex[it * 2 + 1].digitToInt(16)).toByte() }
+
+    // --- MD5 (RFC 1321 test suite) ---------------------------------------
+
+    @Test
+    fun md5KnownVectors() {
+        assertEquals("d41d8cd98f00b204e9800998ecf8427e", hex(md5("".encodeToByteArray())))
+        assertEquals("900150983cd24fb0d6963f7d28e17f72", hex(md5("abc".encodeToByteArray())))
+        assertEquals("f96b697d7cb7938d525a2f31aaf161d0", hex(md5("message digest".encodeToByteArray())))
+        assertEquals(
+            "9e107d9d372bb6826bd81d3542a419d6",
+            hex(md5("The quick brown fox jumps over the lazy dog".encodeToByteArray())),
+        )
+        // Spans multiple 64-byte blocks (80 chars) to exercise chunk boundaries.
+        assertEquals(
+            "57edf4a22be3c955ac49da2e2107b67a",
+            hex(md5("12345678901234567890123456789012345678901234567890123456789012345678901234567890".encodeToByteArray())),
+        )
+    }
+
+    // --- SHA-1 (RFC 3174 / FIPS 180) -------------------------------------
+
+    @Test
+    fun sha1KnownVectors() {
+        assertEquals("da39a3ee5e6b4b0d3255bfef95601890afd80709", hex(sha1("".encodeToByteArray())))
+        assertEquals("a9993e364706816aba3e25717850c26c9cd0d89d", hex(sha1("abc".encodeToByteArray())))
+        assertEquals(
+            "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12",
+            hex(sha1("The quick brown fox jumps over the lazy dog".encodeToByteArray())),
+        )
+        assertEquals(
+            "84983e441c3bd26ebaae4aa1f95129e5e54670f1",
+            hex(sha1("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq".encodeToByteArray())),
+        )
+    }
+
+    // AES core via FIPS-197 vectors: with a zero IV the first CBC ciphertext block
+    // equals the raw ECB block, so this checks the cipher + key schedule (128/192/256).
+
+    private val zeroIv = ByteArray(16)
+
+    private fun firstBlockEcb(key: String, plaintext: String): String {
+        val out = AesCbc.encrypt(bytes(key), zeroIv, bytes(plaintext))
+        return hex(out.copyOf(16))
+    }
+
+    @Test
+    fun aesBlockFips197() {
+        assertEquals(
+            "69c4e0d86a7b0430d8cdb78070b4c55a",
+            firstBlockEcb("000102030405060708090a0b0c0d0e0f", "00112233445566778899aabbccddeeff"),
+        )
+        assertEquals(
+            "dda97ca4864cdfe06eaf70a0ec0d7191",
+            firstBlockEcb("000102030405060708090a0b0c0d0e0f1011121314151617", "00112233445566778899aabbccddeeff"),
+        )
+        assertEquals(
+            "8ea2b7ca516745bfeafc49904b496089",
+            firstBlockEcb(
+                "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+                "00112233445566778899aabbccddeeff",
+            ),
+        )
+    }
+
+    // --- CBC + PKCS#7 round trips (also exercises multi-block decrypt) -----
+
+    @Test
+    fun cbcRoundTripAllKeySizesAndLengths() {
+        val iv = "0102030405060708".encodeToByteArray() // matches the 16-byte miui IV
+        for (keyLen in intArrayOf(16, 32)) {
+            val key = ByteArray(keyLen) { (it * 7 + 1).toByte() }
+            for (len in intArrayOf(0, 1, 15, 16, 17, 31, 32, 100)) {
+                val plain = ByteArray(len) { (it * 3).toByte() }
+                val cipher = AesCbc.encrypt(key, iv, plain)
+                assertTrue(cipher.size % 16 == 0 && cipher.size > len, "ciphertext must be padded to a full block")
+                assertEquals(hex(plain), hex(AesCbc.decrypt(key, iv, cipher)))
+            }
+        }
+    }
+
+    @Test
+    fun cbcMatchesMiuiUsageShape() {
+        // The default 16-byte key path used before login.
+        val key = "miuiotavalided11".encodeToByteArray()
+        val iv = "0102030405060708".encodeToByteArray()
+        val plain = """{"b":"F","c":"1"}"""
+        val cipher = AesCbc.encrypt(key, iv, plain.encodeToByteArray())
+        assertEquals(plain, AesCbc.decrypt(key, iv, cipher).decodeToString())
+    }
+}

--- a/core/src/desktopMain/kotlin/platform/Crypto.desktop.kt
+++ b/core/src/desktopMain/kotlin/platform/Crypto.desktop.kt
@@ -9,13 +9,13 @@ actual suspend fun ownEncrypt(string: String): Pair<String, String> {
     val cipher = KeyStoreUtils.getEncryptionCipher()
     val encrypted = cipher.doFinal(string.toByteArray())
     val iv = cipher.iv
-    return Pair(Base64.Mime.encode(encrypted), Base64.Mime.encode(iv))
+    return Pair(Base64.encode(encrypted), Base64.encode(iv))
 }
 
 @OptIn(ExperimentalEncodingApi::class)
 actual suspend fun ownDecrypt(encryptedText: String, encodedIv: String): String {
-    val encrypted = Base64.Mime.decode(encryptedText)
-    val iv = Base64.Mime.decode(encodedIv)
+    val encrypted = Base64.decode(encryptedText)
+    val iv = Base64.decode(encodedIv)
     val cipher = KeyStoreUtils.getDecryptionCipher(iv) ?: return ""
     return String(cipher.doFinal(encrypted))
 }

--- a/core/src/desktopMain/kotlin/platform/Crypto.desktop.kt
+++ b/core/src/desktopMain/kotlin/platform/Crypto.desktop.kt
@@ -17,7 +17,7 @@ actual suspend fun ownDecrypt(encryptedText: String, encodedIv: String): String 
     val encrypted = Base64.decode(encryptedText)
     val iv = Base64.decode(encodedIv)
     val cipher = KeyStoreUtils.getDecryptionCipher(iv) ?: return ""
-    return String(cipher.doFinal(encrypted))
+    return cipher.doFinal(encrypted).decodeToString()
 }
 
 actual suspend fun generateKey() {

--- a/desktop/proguard-rules-jvm.pro
+++ b/desktop/proguard-rules-jvm.pro
@@ -2,6 +2,3 @@
 -dontwarn okhttp3.internal.platform.**
 -dontwarn io.ktor.network.sockets.SocketBase**
 -dontwarn kotlinx.datetime.**
--dontwarn dev.whyoleg.cryptography.providers.jdk.internal.BouncyCastleBridge
-
--keep class dev.whyoleg.cryptography.providers.jdk.JdkCryptographyProviderContainer

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,6 @@ androidx-lifecycle-compose = "2.10.0"
 clikt = "5.1.0"
 compose-hotReload = "1.1.1"
 compose-plugin = "1.11.1"
-cryptography = "0.6.0"
 image-loader = "1.10.0"
 kotlin = "2.4.0"
 kotlinx-browser = "0.5.0"
@@ -23,7 +22,6 @@ androidx-lifecycle-runtime-compose = { module = "org.jetbrains.androidx.lifecycl
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "compose-plugin" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "compose-plugin" }
-cryptography-provider-optimal = { module = "dev.whyoleg.cryptography:cryptography-provider-optimal", version.ref = "cryptography" }
 image-loader = { module = "io.github.qdsfdhvh:image-loader", version.ref = "image-loader" }
 kotlinx-browser = { module = "org.jetbrains.kotlinx:kotlinx-browser", version.ref = "kotlinx-browser" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinx-datetime" }


### PR DESCRIPTION
cryptography-provider-optimal statically linked OpenSSL into the native CLI binaries (~10-13 MB of libcrypto). Reimplement the only primitives in use -- AES-CBC/PKCS#7, MD5, SHA-1 -- in pure Kotlin under platform.crypto and share them across all targets, so nothing links OpenSSL anymore.

- Strip the symbol table from release CLI binaries via linkerOpts (-Wl,-s on Windows/Linux, -Wl,-x on macOS).
- Unify desktop credential Base64 to Default (was Mime), matching android.

Windows CLI: 13.5 MB -> 7.7 MB, OpenSSL no longer present.